### PR TITLE
Remove sessionId from PaymentForm

### DIFF
--- a/client/src/components/payment-form.tsx
+++ b/client/src/components/payment-form.tsx
@@ -6,10 +6,9 @@ import { useToast } from '@/hooks/use-toast';
 
 interface PaymentFormProps {
   orderId: number | null;
-  sessionId: string;
 }
 
-export default function PaymentForm({ orderId, sessionId }: PaymentFormProps) {
+export default function PaymentForm({ orderId }: PaymentFormProps) {
   const stripe = useStripe();
   const elements = useElements();
   const [, navigate] = useLocation();

--- a/client/src/pages/payment.tsx
+++ b/client/src/pages/payment.tsx
@@ -46,7 +46,7 @@ export default function Payment() {
   }, [orderId]);
 
   const handleGoBack = () => {
-    navigate(`/cart/${sessionId}`);
+    navigate(`/cart/${orderId}`);
   };
 
   const orderData = {
@@ -141,7 +141,7 @@ export default function Payment() {
               
               {paymentMethod === "card" && (
                 <Elements stripe={stripePromise} options={{ clientSecret }}>
-                  <PaymentForm orderId={orderId} sessionId={sessionId} />
+                  <PaymentForm orderId={orderId} />
                 </Elements>
               )}
             </CardContent>


### PR DESCRIPTION
## Summary
- remove unused `sessionId` prop from `PaymentForm`
- update `Payment` page to call `PaymentForm` without `sessionId`
- fix back navigation to use `orderId`

## Testing
- `npm run check` *(fails: client/src/lib/stripe.ts contains JSX but is a `.ts` file)*

------
https://chatgpt.com/codex/tasks/task_e_6876775d0d288322ad5d92cae8a050e4