### PR TITLE
Improve menu loading on QR landing

### DIFF
--- a/client/src/pages/qr-landing.tsx
+++ b/client/src/pages/qr-landing.tsx
@@ -1,5 +1,7 @@
 import { useParams, useLocation } from "wouter";
 import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { queryClient } from "@/lib/queryClient";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Utensils, BookOpen, CreditCard } from "lucide-react";
@@ -21,6 +23,13 @@ export default function QRLanding() {
       return response.json();
     },
   });
+
+  // Prefetch menu items so the menu page loads immediately
+  useEffect(() => {
+    if (sessionData) {
+      queryClient.prefetchQuery({ queryKey: ["/api/menu"] });
+    }
+  }, [sessionData]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary
- prefetch menu items on QR landing page so the menu appears immediately when users press **View Menu**

## Testing
- `npm run check` *(fails: client/src/lib/stripe.ts TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68765af1e8a88322a5ad165b3e7d8098